### PR TITLE
Fix typo: delete unnecessary character on line 244 of `src/search_utils.jl`

### DIFF
--- a/src/search_utils.jl
+++ b/src/search_utils.jl
@@ -241,7 +241,7 @@ function collect_sens_data(exp_loc, sens_param, product_args;
 
         end
 
-   p     save(joinpath(exp_loc, save_dir, "collect_"*join(["$(k)_$(arg[k_idx])" for (k_idx, k) in enumerate(product_args)], '_')*".jld2"), Dict("avg"=>avg_res, "std_err"=>std_err, "sens"=>diff_dict[sens_param], "settings"=>Dict([k=>arg[k_idx] for (k_idx, k) in enumerate(product_args)])))
+        save(joinpath(exp_loc, save_dir, "collect_"*join(["$(k)_$(arg[k_idx])" for (k_idx, k) in enumerate(product_args)], '_')*".jld2"), Dict("avg"=>avg_res, "std_err"=>std_err, "sens"=>diff_dict[sens_param], "settings"=>Dict([k=>arg[k_idx] for (k_idx, k) in enumerate(product_args)])))
     end
 end
 


### PR DESCRIPTION
@mkschleg I believe that you have a typo on line 244 of `src/search_utils.jl`. I think that this is the cause of https://github.com/JuliaCI/Coverage.jl/issues/247