### PR TITLE
Save arbitrary dimension `AbstractArray`s to SQL

### DIFF
--- a/examples/configs/arg_iter_config_sql.toml
+++ b/examples/configs/arg_iter_config_sql.toml
@@ -6,7 +6,7 @@ save_backend="mysql" # mysql only database backend supported
 database="test_iter" # for params and resutsl
 save_dir="test_iter_sql" # for exceptions, settings, and more!
 
-exp_file="examples/experiment.jl"
+exp_file="experiment.jl"
 exp_module_name = "TestExperiment"
 exp_func_name = "main_experiment"
 arg_iter_type = "iter"

--- a/examples/configs/arg_iter_config_sql.toml
+++ b/examples/configs/arg_iter_config_sql.toml
@@ -6,7 +6,7 @@ save_backend="mysql" # mysql only database backend supported
 database="test_iter" # for params and resutsl
 save_dir="test_iter_sql" # for exceptions, settings, and more!
 
-exp_file="experiment.jl"
+exp_file="examples/experiment.jl"
 exp_module_name = "TestExperiment"
 exp_func_name = "main_experiment"
 arg_iter_type = "iter"
@@ -15,6 +15,6 @@ arg_iter_type = "iter"
 steps=102902
 
 [sweep_args]
-opt2 = [5,6,7,8,9]
-opt1 = "1:50"
-"opt3+opt4" = [["a", 1], ["b", 2], ["c", 3]]
+opt2 = [5, 6]
+opt1 = "1:2"
+"opt3+opt4" = [["a", 1], ["b", 2]]

--- a/examples/configs/arg_iter_config_sql.toml
+++ b/examples/configs/arg_iter_config_sql.toml
@@ -15,6 +15,6 @@ arg_iter_type = "iter"
 steps=102902
 
 [sweep_args]
-opt2 = [5, 6]
-opt1 = "1:2"
-"opt3+opt4" = [["a", 1], ["b", 2]]
+opt2 = [5,6,7,8,9]
+opt1 = "1:50"
+"opt3+opt4" = [["a", 1], ["b", 2], ["c", 3]]

--- a/examples/experiment.jl
+++ b/examples/experiment.jl
@@ -17,7 +17,7 @@ import Reproduce:
     - `opt1::Int`: The first argument. Experiment errors on `opt1 == 2`
     - `opt2::Int`: The second argument.
     - `opt2::String`: The Third argument. This is required to be a string
-    - `opt4::Int`: The fourth argument. 
+    - `opt4::Int`: The fourth argument.
     """
     opt1 => 1
     opt2 => 2
@@ -44,7 +44,9 @@ function main_experiment(config::Dict, extra_arg = nothing; progress=false, test
         Dict("mean"=>0.1,
              "vec"=>rand(100),
              "mat"=>rand(10, 10),
-             "vec_vec"=>[rand(10) for _ in 1:10])
+             "vec_vec"=>[rand(10) for _ in 1:10],
+             "3darr"=>reshape(collect(1:27), 3, 3, 3),
+        )
     end
 end
 

--- a/examples/experiment.jl
+++ b/examples/experiment.jl
@@ -41,11 +41,12 @@ function main_experiment(config::Dict, extra_arg = nothing; progress=false, test
             throw("Oh No!!!")
         end
 
-        Dict("mean"=>0.1,
+        Dict(
+            "mean"=>0.1,
              "vec"=>rand(100),
              "mat"=>rand(10, 10),
-             "vec_vec"=>[rand(10) for _ in 1:10],
              "3darr"=>reshape(collect(1:27), 3, 3, 3),
+             "vec_vec"=>[rand(10) for _ in 1:10],
         )
     end
 end


### PR DESCRIPTION
Added the ability to save `AbstractArray`s of arbitrary dimensions to a
SQL table.

Added a return to the main experiment of `examples/experiment.jl` to
demonstrate this.